### PR TITLE
feat: módulo 11 · Manejo de errores

### DIFF
--- a/10-fetch-y-apis/README.md
+++ b/10-fetch-y-apis/README.md
@@ -14,4 +14,4 @@ lo aprendido sobre [asincronía](../09-asincronia/README.md).
 
 ---
 
-[← Asincronía](../09-asincronia/README.md) · [Volver al índice](../README.md)
+[← Asincronía](../09-asincronia/README.md) · [Volver al índice](../README.md) · [Manejo de errores →](../11-manejo-de-errores/README.md)

--- a/11-manejo-de-errores/01-try-catch.md
+++ b/11-manejo-de-errores/01-try-catch.md
@@ -1,0 +1,104 @@
+# try / catch / finally
+
+Hasta los mejores programas fallan: una entrada inesperada, un dato que no existe, una
+operación que no se puede completar. **Manejar errores** consiste en anticipar esos fallos y
+reaccionar con elegancia en lugar de dejar que el programa se rompa.
+
+## Objetivos de aprendizaje
+
+- Usar `try`, `catch` y `finally` para capturar errores.
+- Entender el objeto `Error` y sus propiedades.
+- Saber qué pasa con el flujo del programa cuando ocurre un error.
+
+## Prerrequisitos
+
+- [Funciones](../04-funciones/01-funciones.md)
+- [Condicionales](../03-estructuras-de-control/01-condicionales.md)
+
+## El problema: un error detiene el programa
+
+Cuando ocurre un error y nadie lo maneja, el programa se detiene y no ejecuta lo que venía
+después:
+
+```javascript
+const datos = null;
+
+console.log("Antes");
+console.log(datos.nombre); // ❌ TypeError: Cannot read properties of null
+console.log("Después");    // nunca se ejecuta
+
+// => Antes
+// (luego se lanza el error y "Después" no se imprime)
+```
+
+## La solución: `try` / `catch`
+
+Ponemos el código que podría fallar dentro de `try`. Si algo lanza un error, el control salta
+al bloque `catch`, que recibe el error, y el programa **continúa**.
+
+```javascript
+const datos = null;
+
+console.log("Antes");
+
+try {
+  console.log(datos.nombre);
+} catch (error) {
+  console.log("Ocurrió un error, pero seguimos.");
+}
+
+console.log("Después");
+
+// => Antes
+// => Ocurrió un error, pero seguimos.
+// => Después
+```
+
+## El objeto `Error`
+
+El parámetro que recibe `catch` (aquí `error`) es un objeto `Error` con propiedades útiles:
+
+- `name` — el tipo de error (p. ej. `"TypeError"`).
+- `message` — la descripción legible.
+
+```javascript
+try {
+  const datos = null;
+  console.log(datos.nombre);
+} catch (error) {
+  console.log(error.name);    // => TypeError
+  console.log(error.message); // => Cannot read properties of null (reading 'nombre')
+}
+```
+
+## `finally`
+
+El bloque `finally` se ejecuta **siempre**, haya error o no. Es útil para tareas de limpieza
+(cerrar algo, ocultar un indicador de carga, etc.).
+
+```javascript
+function procesar(valor) {
+  try {
+    console.log("Procesando:", valor.toUpperCase());
+  } catch (error) {
+    console.log("No se pudo procesar.");
+  } finally {
+    console.log("Fin del intento.");
+  }
+}
+
+procesar("hola");  // => Procesando: HOLA   |  => Fin del intento.
+procesar(null);    // => No se pudo procesar. |  => Fin del intento.
+```
+
+## Resumen
+
+- Un error no manejado **detiene** el programa; `try`/`catch` lo evita.
+- El código que podría fallar va en `try`; la reacción al fallo, en `catch`.
+- El `catch` recibe un objeto `Error` con `name` y `message`.
+- `finally` se ejecuta siempre, ideal para limpieza.
+- En la siguiente lección aprenderemos a **lanzar** nuestros propios errores.
+
+---
+
+[Siguiente: Lanzar y crear errores →](./02-lanzar-y-crear-errores.md)

--- a/11-manejo-de-errores/02-lanzar-y-crear-errores.md
+++ b/11-manejo-de-errores/02-lanzar-y-crear-errores.md
@@ -1,0 +1,124 @@
+# Lanzar y crear errores
+
+No solo capturamos errores: también podemos **lanzarlos** nosotros cuando detectamos una
+situación inválida. Lanzar un error a tiempo deja claro qué salió mal y permite que quien usa
+nuestra función lo maneje.
+
+## Objetivos de aprendizaje
+
+- Lanzar errores con `throw`.
+- Conocer los tipos de error integrados (`TypeError`, `RangeError`, etc.).
+- Crear tu propia clase de error.
+
+## Prerrequisitos
+
+- [try / catch / finally](./01-try-catch.md)
+- [Clases](../06-objetos-y-clases/08-clases.md)
+
+## Lanzar con `throw`
+
+`throw` interrumpe la ejecución y "lanza" un valor (lo idiomático es lanzar un objeto
+`Error`). Quien llame a la función puede capturarlo con `try`/`catch`.
+
+```javascript
+function raizCuadrada(numero) {
+  if (numero < 0) {
+    throw new Error("No existe la raíz cuadrada de un número negativo");
+  }
+  return Math.sqrt(numero);
+}
+
+try {
+  console.log(raizCuadrada(16)); // => 4
+  console.log(raizCuadrada(-9)); // lanza el error
+} catch (error) {
+  console.log("Error:", error.message);
+}
+
+// => 4
+// => Error: No existe la raíz cuadrada de un número negativo
+```
+
+> Lanza siempre un objeto `Error` (o derivado), no un texto. `throw "algo"` funciona, pero
+> pierdes `name`, `message` y la traza del error.
+
+## Tipos de error integrados
+
+JavaScript trae varios tipos de error para situaciones comunes. Todos heredan de `Error`:
+
+- **`TypeError`** — un valor no es del tipo esperado (p. ej. llamar algo que no es función).
+- **`RangeError`** — un número fuera del rango permitido.
+- **`SyntaxError`** — código mal escrito (lo lanza el propio motor).
+- **`ReferenceError`** — usar una variable que no existe.
+
+Puedes lanzar el más adecuado para dar más información:
+
+```javascript
+function repetir(texto, veces) {
+  if (typeof texto !== "string") {
+    throw new TypeError("El primer argumento debe ser un texto");
+  }
+  if (veces < 0) {
+    throw new RangeError("El número de veces no puede ser negativo");
+  }
+  return texto.repeat(veces);
+}
+
+try {
+  console.log(repetir("ab", 3)); // => ababab
+  repetir("ab", -1);
+} catch (error) {
+  console.log(`${error.name}: ${error.message}`);
+}
+
+// => ababab
+// => RangeError: El número de veces no puede ser negativo
+```
+
+## Crear tu propia clase de error
+
+Para errores específicos de tu programa, puedes crear una clase que **extienda** `Error`.
+Esto permite distinguirlos con `instanceof`.
+
+```javascript
+class ErrorDeValidacion extends Error {
+  constructor(mensaje) {
+    super(mensaje);
+    this.name = "ErrorDeValidacion";
+  }
+}
+
+function registrar(edad) {
+  if (edad < 18) {
+    throw new ErrorDeValidacion("Debes ser mayor de edad");
+  }
+  return "Registro exitoso";
+}
+
+try {
+  registrar(15);
+} catch (error) {
+  if (error instanceof ErrorDeValidacion) {
+    console.log("Validación falló:", error.message);
+  } else {
+    console.log("Otro error:", error.message);
+  }
+}
+
+// => Validación falló: Debes ser mayor de edad
+```
+
+Llamamos a `super(mensaje)` para reutilizar el constructor de `Error` y ajustamos `name`. Así
+`error.name` será `"ErrorDeValidacion"` y `instanceof` nos deja reaccionar distinto según el
+tipo.
+
+## Resumen
+
+- `throw` lanza un error; lo idiomático es lanzar un objeto `Error`.
+- Hay tipos integrados (`TypeError`, `RangeError`…) para describir mejor el fallo.
+- Puedes crear errores propios extendiendo `Error` y distinguirlos con `instanceof`.
+- En la siguiente lección veremos cómo se manejan los errores en código **asíncrono**.
+
+---
+
+[← try / catch / finally](./01-try-catch.md) · [Siguiente: Errores en código asíncrono →](./03-errores-en-asincronia.md)

--- a/11-manejo-de-errores/03-errores-en-asincronia.md
+++ b/11-manejo-de-errores/03-errores-en-asincronia.md
@@ -1,0 +1,101 @@
+# Errores en código asíncrono
+
+Los errores en tareas asíncronas no se capturan igual que los síncronos: cuando algo falla
+"más tarde", un `try`/`catch` normal alrededor de la llamada no lo atrapa. Esta lección une el
+manejo de errores con lo aprendido en [Asincronía](../09-asincronia/README.md).
+
+## Objetivos de aprendizaje
+
+- Manejar el rechazo de una promesa con `.catch`.
+- Capturar errores asíncronos con `async`/`await` y `try`/`catch`.
+- Entender por qué un `try`/`catch` síncrono no atrapa un error de `setTimeout`.
+
+## Prerrequisitos
+
+- [Promesas](../09-asincronia/02-promesas.md)
+- [async / await](../09-asincronia/03-async-await.md)
+- [Lanzar y crear errores](./02-lanzar-y-crear-errores.md)
+
+## Promesas rechazadas: `.catch`
+
+Cuando una promesa se **rechaza**, el error se maneja con `.catch`, no con `try`/`catch`:
+
+```javascript
+function dividir(a, b) {
+  return new Promise((resolve, reject) => {
+    if (b === 0) {
+      reject(new Error("No se puede dividir entre cero"));
+    } else {
+      resolve(a / b);
+    }
+  });
+}
+
+dividir(10, 0)
+  .then((resultado) => console.log("Resultado:", resultado))
+  .catch((error) => console.log("Capturado:", error.message));
+
+// => Capturado: No se puede dividir entre cero
+```
+
+## Con `async` / `await`: `try` / `catch`
+
+Dentro de una función `async`, `await` "convierte" un rechazo en una excepción que sí puedes
+capturar con `try`/`catch` normal:
+
+```javascript
+function dividir(a, b) {
+  return new Promise((resolve, reject) => {
+    b === 0 ? reject(new Error("No se puede dividir entre cero")) : resolve(a / b);
+  });
+}
+
+async function calcular() {
+  try {
+    const r = await dividir(10, 0);
+    console.log("Resultado:", r);
+  } catch (error) {
+    console.log("Capturado:", error.message);
+  }
+}
+
+calcular();
+
+// => Capturado: No se puede dividir entre cero
+```
+
+## El error clásico: `try`/`catch` y `setTimeout`
+
+Un `try`/`catch` solo atrapa lo que falla **mientras se ejecuta** su bloque. Si el error
+ocurre dentro de un callback que se ejecuta más tarde (como en `setTimeout`), el `try` ya
+terminó y **no** lo captura:
+
+```javascript
+try {
+  setTimeout(() => {
+    throw new Error("¡Fallo tardío!");
+  }, 100);
+} catch (error) {
+  // Esto NUNCA se ejecuta: el try ya terminó cuando el error ocurre.
+  console.log("Capturado:", error.message);
+}
+
+console.log("El try ya terminó");
+
+// => El try ya terminó
+// (y luego el error queda sin capturar)
+```
+
+La solución es manejar el error **dentro** del propio callback, o usar promesas/`async`-`await`
+que sí propagan el error correctamente.
+
+## Resumen
+
+- Una promesa rechazada se maneja con `.catch`.
+- Con `async`/`await`, `await` convierte el rechazo en una excepción capturable con `try`/`catch`.
+- Un `try`/`catch` síncrono **no** atrapa errores que ocurren más tarde (p. ej. en `setTimeout`):
+  manéjalos dentro del callback o con promesas.
+
+---
+
+[← Lanzar y crear errores](./02-lanzar-y-crear-errores.md) · [Siguiente: Ejercicios →](./04-ejercicios.md)

--- a/11-manejo-de-errores/04-ejercicios.md
+++ b/11-manejo-de-errores/04-ejercicios.md
@@ -1,0 +1,188 @@
+# Ejercicios de Manejo de errores
+
+Esta sección contiene ejercicios para practicar `try`/`catch`/`finally`, `throw`, errores
+personalizados y errores en código asíncrono.
+
+## Manejo de errores
+
+### Ejercicio 1 - Capturar un JSON inválido
+
+`JSON.parse` lanza un error si el texto no es JSON válido. Escribe una función `parsearSeguro`
+que intente parsear un texto y, si falla, devuelva `null` en vez de romperse.
+
+**Solución:**
+
+```javascript
+function parsearSeguro(texto) {
+  try {
+    return JSON.parse(texto);
+  } catch (error) {
+    return null;
+  }
+}
+
+console.log(parsearSeguro('{"ok":true}')); // => { ok: true }
+console.log(parsearSeguro("esto no es json")); // => null
+```
+
+Envolvemos `JSON.parse` en un `try`/`catch`: si lanza, devolvemos `null` y el programa
+continúa con normalidad.
+
+**Desafío adicional:**
+
+Permite pasar un valor por defecto como segundo parámetro, en lugar de devolver siempre `null`.
+
+### Ejercicio 2 - Usar finally
+
+Escribe una función que simule abrir y cerrar un recurso: pase lo que pase, debe imprimir
+`"Recurso cerrado"` al final.
+
+**Solución:**
+
+```javascript
+function usarRecurso(valor) {
+  try {
+    console.log("Usando:", valor.toUpperCase());
+  } catch (error) {
+    console.log("Error al usar el recurso");
+  } finally {
+    console.log("Recurso cerrado");
+  }
+}
+
+usarRecurso("dato");
+usarRecurso(null);
+
+// => Usando: DATO
+// => Recurso cerrado
+// => Error al usar el recurso
+// => Recurso cerrado
+```
+
+`finally` se ejecuta tanto en el caso exitoso como en el fallido, ideal para liberar
+recursos.
+
+**Desafío adicional:**
+
+Haz que la función devuelva `true` si tuvo éxito y `false` si falló.
+
+### Ejercicio 3 - Lanzar un error de validación
+
+Escribe una función `dividir(a, b)` que lance un error si `b` es `0`, y captúrala mostrando el
+mensaje.
+
+**Solución:**
+
+```javascript
+function dividir(a, b) {
+  if (b === 0) {
+    throw new Error("No se puede dividir entre cero");
+  }
+  return a / b;
+}
+
+try {
+  console.log(dividir(10, 2)); // => 5
+  console.log(dividir(10, 0)); // lanza el error
+} catch (error) {
+  console.log("Error:", error.message);
+}
+
+// => 5
+// => Error: No se puede dividir entre cero
+```
+
+Validamos la condición inválida y lanzamos un `Error` descriptivo; el `catch` lo recibe y
+muestra su `message`.
+
+**Desafío adicional:**
+
+Lanza un `TypeError` si alguno de los argumentos no es un número.
+
+### Ejercicio 4 - Error personalizado con instanceof
+
+Crea una clase `ErrorDeSaldo` que extienda `Error`. Úsala en una función `retirar` que la
+lance si el monto supera el saldo, y distíngue ese error con `instanceof`.
+
+**Solución:**
+
+```javascript
+class ErrorDeSaldo extends Error {
+  constructor(mensaje) {
+    super(mensaje);
+    this.name = "ErrorDeSaldo";
+  }
+}
+
+function retirar(saldo, monto) {
+  if (monto > saldo) {
+    throw new ErrorDeSaldo("Fondos insuficientes");
+  }
+  return saldo - monto;
+}
+
+try {
+  console.log(retirar(100, 30));  // => 70
+  console.log(retirar(100, 200)); // lanza ErrorDeSaldo
+} catch (error) {
+  if (error instanceof ErrorDeSaldo) {
+    console.log("Saldo:", error.message);
+  } else {
+    console.log("Otro error:", error.message);
+  }
+}
+
+// => 70
+// => Saldo: Fondos insuficientes
+```
+
+Al extender `Error` y ajustar `name`, podemos reconocer nuestro error con `instanceof` y
+reaccionar de forma específica.
+
+**Desafío adicional:**
+
+Añade una propiedad `this.faltante` con cuánto dinero falta y muéstrala en el `catch`.
+
+### Ejercicio 5 - Errores con async / await
+
+Crea una función asíncrona `obtenerDato(id)` que se rechace si `id` es menor o igual a 0, y
+consúmela con `async`/`await` y `try`/`catch`.
+
+**Solución:**
+
+```javascript
+function obtenerDato(id) {
+  return new Promise((resolve, reject) => {
+    setTimeout(() => {
+      if (id <= 0) {
+        reject(new Error("id inválido"));
+      } else {
+        resolve(`dato-${id}`);
+      }
+    }, 200);
+  });
+}
+
+async function mostrar(id) {
+  try {
+    const dato = await obtenerDato(id);
+    console.log("Obtenido:", dato);
+  } catch (error) {
+    console.log("Error:", error.message);
+  }
+}
+
+mostrar(5);   // => Obtenido: dato-5
+mostrar(-1);  // => Error: id inválido
+```
+
+`await` convierte el rechazo de la promesa en una excepción que el `try`/`catch` captura, igual
+que con código síncrono.
+
+**Desafío adicional:**
+
+Añade un `finally` que imprima `"Consulta finalizada"` en ambos casos.
+
+---
+
+[← Errores en código asíncrono](./03-errores-en-asincronia.md) · [Volver al módulo](./README.md)

--- a/11-manejo-de-errores/README.md
+++ b/11-manejo-de-errores/README.md
@@ -1,0 +1,16 @@
+# 11 · Manejo de errores
+
+Cómo anticipar y manejar los fallos para que el programa reaccione con elegancia en lugar de
+romperse: `try`/`catch`/`finally`, lanzar errores con `throw`, errores propios y el manejo de
+errores en código asíncrono.
+
+## Lecciones
+
+1. [try / catch / finally](./01-try-catch.md)
+2. [Lanzar y crear errores](./02-lanzar-y-crear-errores.md)
+3. [Errores en código asíncrono](./03-errores-en-asincronia.md)
+4. [Ejercicios](./04-ejercicios.md)
+
+---
+
+[← Fetch y APIs](../10-fetch-y-apis/README.md) · [Volver al índice](../README.md)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
   ejercicios y ejemplos verificados con Node.
 - Módulo **10 · Fetch y APIs**: APIs/JSON y `fetch` (GET, manejo de errores con
   `response.ok`, POST), con ejercicios verificados contra una API pública real.
+- Módulo **11 · Manejo de errores**: `try`/`catch`/`finally`, `throw` y errores propios, y
+  manejo de errores en código asíncrono, con ejercicios verificados con Node.
 
 ## [0.2.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -106,7 +106,12 @@ anterior, combina teoría con ejemplos y cierra con ejercicios para practicar.
     1. [APIs y JSON](./10-fetch-y-apis/01-apis-y-json.md)
     2. [fetch](./10-fetch-y-apis/02-fetch.md)
     3. [Ejercicios](./10-fetch-y-apis/03-ejercicios.md)
-11. **Proyectos**
+11. **Manejo de errores**
+    1. [try / catch / finally](./11-manejo-de-errores/01-try-catch.md)
+    2. [Lanzar y crear errores](./11-manejo-de-errores/02-lanzar-y-crear-errores.md)
+    3. [Errores en código asíncrono](./11-manejo-de-errores/03-errores-en-asincronia.md)
+    4. [Ejercicios](./11-manejo-de-errores/04-ejercicios.md)
+12. **Proyectos**
     1. [Conversor de monedas](./proyectos/conversor-monedas.md)
 
 > ¿Qué viene después? Consulta el [roadmap de contenido](./docs/product/roadmap.md).
@@ -146,7 +151,7 @@ console.log("¡Hola, mundo!"); // => ¡Hola, mundo!
 
 ```text
 .
-├── 01-introduccion … 10-fetch-y-apis/  # Módulos del curso (lecciones .md numeradas)
+├── 01-introduccion … 11-manejo-de-errores/  # Módulos del curso (lecciones .md numeradas)
 ├── proyectos/                  # Proyectos prácticos
 ├── docs/                       # Cómo se construye y mantiene el curso
 ├── specs/                      # Plantillas para planear contenido nuevo

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -9,25 +9,26 @@ Módulos publicados:
 
 | Módulo                       | Estado      |
 | ---------------------------- | ----------- |
-| 01 · Introducción            | ✅ Completo (ampliar historia) |
+| 01 · Introducción            | ✅ Completo |
 | 02 · Fundamentos             | ✅ Completo |
 | 03 · Estructuras de control  | ✅ Completo |
 | 04 · Funciones               | ✅ Completo |
 | 05 · Arrays                  | ✅ Completo |
 | 06 · Objetos y clases        | ✅ Completo |
-| 07 · POO                     | 🚧 Falta el archivo de ejercicios |
+| 07 · POO                     | ✅ Completo |
 | 08 · DOM y eventos           | ✅ Completo |
 | 09 · Asincronía              | ✅ Completo (callbacks, promesas, async/await) |
 | 10 · Fetch y APIs            | ✅ Completo (APIs, JSON, fetch, POST) |
+| 11 · Manejo de errores       | ✅ Completo (try/catch, throw, errores async) |
 | Proyectos · Conversor de monedas | ✅ Completo |
 
-## Correcciones pendientes (prioridad alta)
+## Correcciones (completadas en v0.2.0)
 
-- [ ] Escribir `07-poo/07-ejercicios.md` (actualmente vacío).
-- [ ] Ampliar `01-introduccion/02-historia-javascript.md` (origen 1995, Brendan Eich, ES5/ES6+).
-- [ ] Añadir un `README.md` por módulo (índice de lecciones).
-- [ ] Normalizar los títulos de las lecciones según [`estilo-de-contenido.md`](../conventions/estilo-de-contenido.md).
-- [ ] Añadir ejemplos `.html` de referencia para el módulo 08 (DOM).
+- [x] Escribir `07-poo/07-ejercicios.md` (estaba vacío).
+- [x] Ampliar `01-introduccion/02-historia-javascript.md` (origen 1995, Brendan Eich, ES5/ES6+).
+- [x] Añadir un `README.md` por módulo (índice de lecciones).
+- [x] Normalizar los títulos de las lecciones según [`estilo-de-contenido.md`](../conventions/estilo-de-contenido.md).
+- [x] Añadir ejemplos `.html` de referencia para el módulo 08 (DOM).
 
 ## Contenido nuevo propuesto
 
@@ -35,7 +36,7 @@ Temas que un curso de JavaScript moderno debería cubrir y que aún no están:
 
 - [x] **Asincronía** — callbacks, Promises, `async`/`await`. *(módulo 09)*
 - [x] **Fetch y APIs** — consumir datos con `fetch`, JSON, manejo de respuestas. *(módulo 10)*
-- [ ] **Manejo de errores** — `try`/`catch`/`finally`, `throw`, errores en asincronía.
+- [x] **Manejo de errores** — `try`/`catch`/`finally`, `throw`, errores en asincronía. *(módulo 11)*
 - [ ] **Módulos ES** — `import`/`export`, organización de código.
 - [ ] **Métodos avanzados de String y Number**, fechas (`Date`).
 - [ ] **Proyectos nuevos** — al menos uno que use DOM + asincronía (p. ej. consumir una API pública).


### PR DESCRIPTION
# Descripción

Añade el **módulo 11 · Manejo de errores**, tercer tema del roadmap. Cierra el bloque
moderno junto con Asincronía (09) y Fetch (10).

## Tipo de cambio

- [x] Lección o módulo nuevo
- [x] Ejercicios o proyecto

## Contenido

- `01-try-catch.md` — `try`/`catch`/`finally`, el objeto `Error` (`name`, `message`).
- `02-lanzar-y-crear-errores.md` — `throw`, tipos integrados (`TypeError`, `RangeError`…),
  clases de error propias e `instanceof`.
- `03-errores-en-asincronia.md` — `.catch`, `async`/`await` con `try`/`catch`, y por qué un
  `try`/`catch` síncrono no atrapa errores de `setTimeout`.
- `04-ejercicios.md` — 5 ejercicios con soluciones verificadas.
- `README.md` del módulo + índice del README raíz, roadmap y CHANGELOG.

## Notas para quien revisa

- **Todos** los ejemplos de las lecciones y las 5 soluciones se ejecutaron con `node` y
  producen exactamente la salida anotada (incluido el mensaje exacto del `TypeError` y el
  caso del error no capturado de `setTimeout`).
- El roadmap también marca como completadas las correcciones que ya entraron en v0.2.0.
- markdownlint 0 errores (111 archivos), enlaces internos resueltos.

## Checklist

- [x] Sigue las convenciones de `docs/conventions/`
- [x] Contenido en español
- [x] Ejemplos verificados (`node`) y la salida descrita es la real
- [x] Markdownlint y enlaces pasan
- [x] Índices actualizados (README, roadmap)
- [x] Entrada en `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)