### PR TITLE
feat: módulo 12 · Módulos ES

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,11 @@ jobs:
         with:
           node-version: "lts/*"
 
-      - name: Verificar sintaxis de los .js
+      - name: Verificar sintaxis de los ejemplos (.js / .mjs)
         run: |
           shopt -s globstar nullglob
           fail=0
-          for f in **/*.js; do
+          for f in **/*.js **/*.mjs; do
             node --check "$f" || fail=1
           done
           exit $fail

--- a/11-manejo-de-errores/README.md
+++ b/11-manejo-de-errores/README.md
@@ -13,4 +13,4 @@ errores en código asíncrono.
 
 ---
 
-[← Fetch y APIs](../10-fetch-y-apis/README.md) · [Volver al índice](../README.md)
+[← Fetch y APIs](../10-fetch-y-apis/README.md) · [Volver al índice](../README.md) · [Módulos ES →](../12-modulos-es/README.md)

--- a/12-modulos-es/01-que-son-los-modulos.md
+++ b/12-modulos-es/01-que-son-los-modulos.md
@@ -1,0 +1,81 @@
+# ¿Qué son los módulos?
+
+A medida que un programa crece, meter todo el código en un solo archivo se vuelve
+inmanejable. Los **módulos** permiten dividir el código en archivos separados y reutilizables,
+donde cada archivo decide **qué comparte** con los demás y **qué mantiene privado**.
+
+## Objetivos de aprendizaje
+
+- Entender qué problema resuelven los módulos.
+- Conocer el ámbito (scope) de un módulo.
+- Saber cómo ejecutar módulos ES en el navegador y en Node.js.
+
+## Prerrequisitos
+
+- [Funciones](../04-funciones/01-funciones.md)
+- [Objetos](../06-objetos-y-clases/04-objetos.md)
+
+## El problema: todo en el ámbito global
+
+Antes de los módulos, varios archivos `<script>` compartían el **mismo ámbito global**: una
+variable declarada en uno era visible (y pisable) por los demás. Eso provocaba colisiones de
+nombres y un código difícil de mantener.
+
+```javascript
+// archivo-a.js
+let total = 10;
+
+// archivo-b.js
+let total = 5; // 💥 colisión: ambos comparten el ámbito global
+```
+
+## La solución: módulos ES
+
+Los **módulos ES** (ESM), estandarizados en ES6, hacen que **cada archivo tenga su propio
+ámbito**. Nada se comparte salvo lo que **exportas** explícitamente, y otro archivo lo usa
+solo si lo **importa**.
+
+- `export` — marca qué cosas de un módulo quedan disponibles para otros.
+- `import` — trae a un módulo las cosas exportadas por otro.
+
+Lo veremos en detalle en la [siguiente lección](./02-export-e-import.md).
+
+## Ámbito de módulo
+
+Todo lo que declaras en un módulo es **privado** por defecto: solo existe dentro de ese
+archivo a menos que lo exportes. Esto elimina las colisiones del ámbito global.
+
+## Cómo se ejecutan los módulos ES
+
+Los módulos no se ejecutan como un script normal; hay que indicar que el archivo **es un
+módulo**:
+
+- **En el navegador**: añade `type="module"` a la etiqueta script.
+
+  ```html
+  <script type="module" src="main.js"></script>
+  ```
+
+- **En Node.js**: usa la extensión `.mjs`, o pon `"type": "module"` en el `package.json`.
+
+  ```bash
+  node main.mjs
+  ```
+
+En la carpeta [`ejemplos/`](./ejemplos) tienes
+[`operaciones.mjs`](./ejemplos/operaciones.mjs) y [`main.mjs`](./ejemplos/main.mjs) listos
+para ejecutar con `node main.mjs`.
+
+> Nota: gran parte de este curso (clases, `let`/`const`, etc.) ya usa características de ES6.
+> Los módulos son una de ellas; los vemos ahora con calma porque cobran sentido cuando el
+> proyecto tiene varios archivos.
+
+## Resumen
+
+- Los **módulos** dividen el código en archivos con su propio ámbito.
+- Cada módulo comparte solo lo que **exporta**; otro lo usa si lo **importa**.
+- Para ejecutarlos: `type="module"` en el navegador, o `.mjs` / `"type": "module"` en Node.
+
+---
+
+[Siguiente: export e import →](./02-export-e-import.md)

--- a/12-modulos-es/02-export-e-import.md
+++ b/12-modulos-es/02-export-e-import.md
@@ -1,0 +1,120 @@
+# export e import
+
+Ya sabemos para qué sirven los módulos; ahora veamos la sintaxis para **compartir** código
+(`export`) y **usarlo** desde otro archivo (`import`).
+
+## Objetivos de aprendizaje
+
+- Usar exportaciones **con nombre** y **por defecto**.
+- Importar, renombrar (`as`) e importar todo (`* as`).
+- Conocer la importación dinámica `import()`.
+
+## Prerrequisitos
+
+- [¿Qué son los módulos?](./01-que-son-los-modulos.md)
+
+## Exportaciones con nombre
+
+Puedes exportar tantas cosas como quieras por su nombre. Se importan **entre llaves** usando
+exactamente esos nombres.
+
+```javascript
+// operaciones.mjs
+export const PI = 3.1416;
+
+export function sumar(a, b) {
+  return a + b;
+}
+
+export function restar(a, b) {
+  return a - b;
+}
+```
+
+```javascript
+// main.mjs
+import { PI, sumar } from "./operaciones.mjs";
+
+console.log(PI);          // => 3.1416
+console.log(sumar(2, 3)); // => 5
+```
+
+## Exportación por defecto
+
+Cada módulo puede tener **una** exportación por defecto (`export default`). Se importa **sin
+llaves** y puedes darle el nombre que quieras.
+
+```javascript
+// operaciones.mjs
+export default function saludar(nombre) {
+  return `Hola, ${nombre}`;
+}
+```
+
+```javascript
+// main.mjs
+import saludar from "./operaciones.mjs"; // sin llaves
+console.log(saludar("Ada")); // => Hola, Ada
+```
+
+Puedes combinar el default y los nombrados en un mismo `import` (el default va primero):
+
+```javascript
+import saludar, { PI, sumar, restar } from "./operaciones.mjs";
+```
+
+> Los archivos [`ejemplos/operaciones.mjs`](./ejemplos/operaciones.mjs) y
+> [`ejemplos/main.mjs`](./ejemplos/main.mjs) contienen exactamente este ejemplo. Ejecútalo
+> con `node main.mjs` y verás:
+>
+> ```text
+> Hola, Ada
+> PI: 3.1416
+> 2 + 3 = 5
+> 5 - 1 = 4
+> ```
+
+## Renombrar al importar (`as`)
+
+Si un nombre choca con otro o quieres uno más claro, usa `as`:
+
+```javascript
+import { sumar as agregar } from "./operaciones.mjs";
+console.log(agregar(1, 1)); // => 2
+```
+
+## Importar todo (`* as`)
+
+Puedes traer todas las exportaciones con nombre dentro de un objeto:
+
+```javascript
+import * as operaciones from "./operaciones.mjs";
+
+console.log(operaciones.PI);          // => 3.1416
+console.log(operaciones.sumar(4, 4)); // => 8
+```
+
+## Importación dinámica
+
+`import()` (como función) carga un módulo **bajo demanda** y devuelve una promesa. Es útil
+para cargar algo solo cuando se necesita.
+
+```javascript
+async function cargar() {
+  const operaciones = await import("./operaciones.mjs");
+  console.log(operaciones.sumar(10, 5)); // => 15
+}
+
+cargar();
+```
+
+## Resumen
+
+- **Con nombre**: `export const/function …` → `import { nombre } from "…"`.
+- **Por defecto**: `export default …` → `import loQueQuieras from "…"` (sin llaves).
+- `as` renombra; `* as obj` importa todo en un objeto.
+- `import()` carga módulos de forma dinámica y devuelve una promesa.
+
+---
+
+[← ¿Qué son los módulos?](./01-que-son-los-modulos.md) · [Siguiente: Ejercicios →](./03-ejercicios.md)

--- a/12-modulos-es/03-ejercicios.md
+++ b/12-modulos-es/03-ejercicios.md
@@ -1,0 +1,117 @@
+# Ejercicios de Módulos ES
+
+Esta sección contiene ejercicios para practicar `export` e `import`.
+
+> Cada ejercicio usa **dos archivos**. Guárdalos con extensión `.mjs` en la misma carpeta y
+> ejecuta el principal con `node main.mjs`.
+
+## Módulos ES
+
+### Ejercicio 1 - Exportaciones con nombre
+
+Crea un módulo `figuras.mjs` que exporte dos funciones: `areaCuadrado(lado)` y
+`areaRectangulo(base, altura)`. Impórtalas en `main.mjs` y úsalas.
+
+**Solución:**
+
+```javascript
+// figuras.mjs
+export function areaCuadrado(lado) {
+  return lado * lado;
+}
+
+export function areaRectangulo(base, altura) {
+  return base * altura;
+}
+```
+
+```javascript
+// main.mjs
+import { areaCuadrado, areaRectangulo } from "./figuras.mjs";
+
+console.log(areaCuadrado(4));        // => 16
+console.log(areaRectangulo(3, 5));   // => 15
+```
+
+Cada función se exporta con su nombre y se importa entre llaves usando ese mismo nombre.
+
+**Desafío adicional:**
+
+Añade y exporta una constante `VERSION` y muéstrala desde `main.mjs`.
+
+### Ejercicio 2 - Exportación por defecto
+
+Crea un módulo `saludo.mjs` con una **exportación por defecto**: una función que reciba un
+nombre y devuelva `"¡Bienvenida, <nombre>!"`. Impórtala con el nombre que prefieras.
+
+**Solución:**
+
+```javascript
+// saludo.mjs
+export default function bienvenida(nombre) {
+  return `¡Bienvenida, ${nombre}!`;
+}
+```
+
+```javascript
+// main.mjs
+import saludar from "./saludo.mjs"; // sin llaves, nombre libre
+
+console.log(saludar("Grace")); // => ¡Bienvenida, Grace!
+```
+
+La exportación por defecto se importa sin llaves y puedes nombrarla como quieras (`saludar`).
+
+**Desafío adicional:**
+
+Añade además una exportación con nombre `IDIOMA = "es"` y muéstrala junto al saludo.
+
+### Ejercicio 3 - Renombrar e importar todo
+
+Reutiliza `figuras.mjs` del ejercicio 1. En `main.mjs`, importa **todo** el módulo en un
+objeto llamado `figuras` y usa sus funciones.
+
+**Solución:**
+
+```javascript
+// main.mjs
+import * as figuras from "./figuras.mjs";
+
+console.log(figuras.areaCuadrado(2));      // => 4
+console.log(figuras.areaRectangulo(2, 6)); // => 12
+```
+
+`import * as figuras` agrupa todas las exportaciones con nombre dentro del objeto `figuras`,
+al que accedes con punto.
+
+**Desafío adicional:**
+
+Importa solo `areaCuadrado` pero renómbrala a `cuadrado` con `as`.
+
+### Ejercicio 4 - Importación dinámica
+
+Carga `figuras.mjs` de forma **dinámica** dentro de una función `async` y usa una de sus
+funciones.
+
+**Solución:**
+
+```javascript
+// main.mjs
+async function calcular() {
+  const figuras = await import("./figuras.mjs");
+  console.log(figuras.areaCuadrado(5)); // => 25
+}
+
+calcular();
+```
+
+`import()` como función devuelve una promesa que se resuelve con el módulo; con `await`
+obtenemos sus exportaciones solo cuando hacen falta.
+
+**Desafío adicional:**
+
+Muestra un mensaje `"Módulo cargado"` justo antes de usar la función.
+
+---
+
+[← export e import](./02-export-e-import.md) · [Volver al módulo](./README.md)

--- a/12-modulos-es/README.md
+++ b/12-modulos-es/README.md
@@ -1,0 +1,19 @@
+# 12 · Módulos ES
+
+Cómo dividir el código en archivos reutilizables con su propio ámbito, compartiendo solo lo
+necesario mediante `export` e `import`. Es la base para organizar proyectos de varios
+archivos.
+
+> Los ejemplos se ejecutan como módulos: usa `.mjs` con Node (`node main.mjs`) o
+> `type="module"` en el navegador. En [`ejemplos/`](./ejemplos) hay dos archivos listos para
+> correr.
+
+## Lecciones
+
+1. [¿Qué son los módulos?](./01-que-son-los-modulos.md)
+2. [export e import](./02-export-e-import.md)
+3. [Ejercicios](./03-ejercicios.md)
+
+---
+
+[← Manejo de errores](../11-manejo-de-errores/README.md) · [Volver al índice](../README.md)

--- a/12-modulos-es/ejemplos/main.mjs
+++ b/12-modulos-es/ejemplos/main.mjs
@@ -1,0 +1,11 @@
+// main.mjs — un módulo que IMPORTA desde operaciones.mjs.
+// Ejecuta este archivo con:  node main.mjs
+
+// El default se importa sin llaves (con el nombre que quieras);
+// las exportaciones con nombre van entre llaves.
+import saludar, { PI, sumar, restar } from "./operaciones.mjs";
+
+console.log(saludar("Ada"));
+console.log("PI:", PI);
+console.log("2 + 3 =", sumar(2, 3));
+console.log("5 - 1 =", restar(5, 1));

--- a/12-modulos-es/ejemplos/operaciones.mjs
+++ b/12-modulos-es/ejemplos/operaciones.mjs
@@ -1,0 +1,17 @@
+// operaciones.mjs — un módulo que EXPORTA valores y funciones.
+
+// Exportaciones con nombre (named exports):
+export const PI = 3.1416;
+
+export function sumar(a, b) {
+  return a + b;
+}
+
+export function restar(a, b) {
+  return a - b;
+}
+
+// Exportación por defecto (default export): solo puede haber una por módulo.
+export default function saludar(nombre) {
+  return `Hola, ${nombre}`;
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,9 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
   `response.ok`, POST), con ejercicios verificados contra una API pública real.
 - Módulo **11 · Manejo de errores**: `try`/`catch`/`finally`, `throw` y errores propios, y
   manejo de errores en código asíncrono, con ejercicios verificados con Node.
+- Módulo **12 · Módulos ES**: `export`/`import` (con nombre, por defecto, `as`, `* as`,
+  importación dinámica), con archivos `.mjs` de ejemplo ejecutables y ejercicios.
+- CI: la verificación de sintaxis de ejemplos ahora cubre también archivos `.mjs`.
 
 ## [0.2.0] - 2026-06-30
 

--- a/README.md
+++ b/README.md
@@ -111,7 +111,11 @@ anterior, combina teoría con ejemplos y cierra con ejercicios para practicar.
     2. [Lanzar y crear errores](./11-manejo-de-errores/02-lanzar-y-crear-errores.md)
     3. [Errores en código asíncrono](./11-manejo-de-errores/03-errores-en-asincronia.md)
     4. [Ejercicios](./11-manejo-de-errores/04-ejercicios.md)
-12. **Proyectos**
+12. **Módulos ES**
+    1. [¿Qué son los módulos?](./12-modulos-es/01-que-son-los-modulos.md)
+    2. [export e import](./12-modulos-es/02-export-e-import.md)
+    3. [Ejercicios](./12-modulos-es/03-ejercicios.md)
+13. **Proyectos**
     1. [Conversor de monedas](./proyectos/conversor-monedas.md)
 
 > ¿Qué viene después? Consulta el [roadmap de contenido](./docs/product/roadmap.md).
@@ -151,7 +155,7 @@ console.log("¡Hola, mundo!"); // => ¡Hola, mundo!
 
 ```text
 .
-├── 01-introduccion … 11-manejo-de-errores/  # Módulos del curso (lecciones .md numeradas)
+├── 01-introduccion … 12-modulos-es/  # Módulos del curso (lecciones .md numeradas)
 ├── proyectos/                  # Proyectos prácticos
 ├── docs/                       # Cómo se construye y mantiene el curso
 ├── specs/                      # Plantillas para planear contenido nuevo

--- a/docs/product/roadmap.md
+++ b/docs/product/roadmap.md
@@ -20,6 +20,7 @@ Módulos publicados:
 | 09 · Asincronía              | ✅ Completo (callbacks, promesas, async/await) |
 | 10 · Fetch y APIs            | ✅ Completo (APIs, JSON, fetch, POST) |
 | 11 · Manejo de errores       | ✅ Completo (try/catch, throw, errores async) |
+| 12 · Módulos ES              | ✅ Completo (export/import, default, dinámico) |
 | Proyectos · Conversor de monedas | ✅ Completo |
 
 ## Correcciones (completadas en v0.2.0)
@@ -37,7 +38,7 @@ Temas que un curso de JavaScript moderno debería cubrir y que aún no están:
 - [x] **Asincronía** — callbacks, Promises, `async`/`await`. *(módulo 09)*
 - [x] **Fetch y APIs** — consumir datos con `fetch`, JSON, manejo de respuestas. *(módulo 10)*
 - [x] **Manejo de errores** — `try`/`catch`/`finally`, `throw`, errores en asincronía. *(módulo 11)*
-- [ ] **Módulos ES** — `import`/`export`, organización de código.
+- [x] **Módulos ES** — `import`/`export`, organización de código. *(módulo 12)*
 - [ ] **Métodos avanzados de String y Number**, fechas (`Date`).
 - [ ] **Proyectos nuevos** — al menos uno que use DOM + asincronía (p. ej. consumir una API pública).
 


### PR DESCRIPTION
# Descripción

Añade el **módulo 12 · Módulos ES**, cuarto tema del roadmap: cómo organizar el código en
archivos reutilizables con `export`/`import`.

## Tipo de cambio

- [x] Lección o módulo nuevo
- [x] Ejercicios o proyecto
- [x] Configuración / tooling (CI verifica `.mjs`)

## Contenido

- `01-que-son-los-modulos.md` — problema del ámbito global, ámbito de módulo, cómo ejecutar
  módulos (`.mjs` / `type="module"`).
- `02-export-e-import.md` — exportaciones con nombre y por defecto, `as`, `* as`, `import()` dinámico.
- `03-ejercicios.md` — 4 ejercicios con soluciones verificadas.
- `ejemplos/operaciones.mjs` y `ejemplos/main.mjs` — ejecutables con `node main.mjs`.
- `README.md` del módulo + índice del README raíz, roadmap y CHANGELOG.

## Notas para quien revisa

- **Todos** los ejemplos y las 4 soluciones se ejecutaron con `node` (como módulos `.mjs`) y
  producen exactamente la salida anotada.
- El job de CI `ejemplos` ahora cubre también `**/*.mjs`.
- markdownlint 0 errores (115 archivos), enlaces internos resueltos.

## Checklist

- [x] Sigue las convenciones de `docs/conventions/`
- [x] Contenido en español
- [x] Ejemplos verificados (`node`) y la salida descrita es la real
- [x] Markdownlint y enlaces pasan
- [x] Índices actualizados (README, roadmap)
- [x] Entrada en `CHANGELOG.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)