### PR TITLE
chore(release): prepara v0.3.0 en el changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+## [0.3.0] - 2026-06-30
+
 ### Added
 
 - Módulo **09 · Asincronía**: lecciones de callbacks, promesas y `async`/`await`, con
@@ -68,7 +70,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 <!--
 Enlaces de comparación entre versiones (ajusta a tu repositorio):
-[Unreleased]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.2.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.3.0...HEAD
+[0.3.0]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/brayandiazc/aprendiendo-javascript/releases/tag/v0.1.0
 -->


### PR DESCRIPTION
Cierra la sección `[0.3.0]` del changelog antes de publicar en `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)