### PR TITLE
fix(ci): corrige el chequeo de enlaces (lychee)

### DIFF
--- a/.github/scripts/format-markdown.sh
+++ b/.github/scripts/format-markdown.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+# Formatea los archivos del curso con Prettier.
+# No requiere instalar Prettier: lo ejecuta vía npx (necesita Node.js).
+#
+# Uso:
+#   bash .github/scripts/format-markdown.sh           # formatea (--write)
+#   bash .github/scripts/format-markdown.sh --check    # solo verifica, no escribe
+#
+# Por defecto formatea Markdown y los ejemplos de código (.js / .mjs).
+
+set -e
+
+MODE="--write"
+if [ "$1" = "--check" ]; then
+	MODE="--check"
+fi
+
+if ! command -v npx &> /dev/null; then
+	echo "Error: se necesita Node.js (npx) para ejecutar Prettier." >&2
+	echo "Instálalo desde https://nodejs.org/" >&2
+	exit 1
+fi
+
+echo "Ejecutando Prettier ($MODE) sobre Markdown y ejemplos…"
+npx --yes prettier@3 "$MODE" "**/*.{md,js,mjs}"
+echo "Listo."

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,10 @@ jobs:
       - name: Revisar enlaces
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--no-progress --verbose './**/*.md'"
+          # Excluimos _sidebar.md (navegación de docsify con enlaces raíz-relativos
+          # que lychee no resuelve) y la propia URL de GitHub Pages (chequeo circular
+          # e intermitente durante los redespliegues).
+          args: "--no-progress --exclude-path ./_sidebar.md --exclude brayandiazc.github.io './**/*.md'"
           fail: true
 
   ejemplos:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,10 +24,9 @@ jobs:
       - name: Revisar enlaces
         uses: lycheeverse/lychee-action@v2
         with:
-          # Excluimos _sidebar.md (navegación de docsify con enlaces raíz-relativos
-          # que lychee no resuelve) y la propia URL de GitHub Pages (chequeo circular
-          # e intermitente durante los redespliegues).
-          args: "--no-progress --exclude-path ./_sidebar.md --exclude brayandiazc.github.io './**/*.md'"
+          # Las exclusiones (_sidebar.md y la URL de Pages) están en lychee.toml,
+          # que lychee detecta automáticamente en la raíz del repo.
+          args: "--no-progress './**/*.md'"
           fail: true
 
   ejemplos:

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,3 @@
+node_modules/
+CHANGELOG.md
+_sidebar.md

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,6 @@
+{
+  "proseWrap": "preserve",
+  "printWidth": 100,
+  "semi": true,
+  "singleQuote": false
+}

--- a/docs/conventions/quality-tooling.md
+++ b/docs/conventions/quality-tooling.md
@@ -32,10 +32,20 @@ npx markdown-link-check **/*.md
 
 ## Formato (opcional)
 
-Prettier puede formatear Markdown y JS de ejemplo de forma consistente:
+Hay un script que formatea el Markdown y los ejemplos (`.js`/`.mjs`) con Prettier vía `npx`
+(no necesitas instalar nada, solo Node.js):
 
 ```bash
-npx prettier --write "**/*.{md,js}"
+bash .github/scripts/format-markdown.sh          # formatea (--write)
+bash .github/scripts/format-markdown.sh --check   # solo verifica, no escribe
+```
+
+La configuración está en [`.prettierrc`](../../.prettierrc) (con `proseWrap: preserve`, así
+que **no reescribe** los párrafos existentes) y las exclusiones en
+[`.prettierignore`](../../.prettierignore). También puedes invocar Prettier directamente:
+
+```bash
+npx prettier --write "**/*.{md,js,mjs}"
 ```
 
 ## CI

--- a/lychee.toml
+++ b/lychee.toml
@@ -1,0 +1,9 @@
+# Configuración de lychee (verificación de enlaces en CI).
+
+# No revisar _sidebar.md: usa enlaces raíz-relativos (/modulo/...) que necesita
+# docsify para la versión web, pero que lychee no resuelve como rutas locales.
+exclude_path = ["_sidebar.md"]
+
+# No revisar la propia URL de GitHub Pages: es un chequeo circular y puede dar 404
+# de forma intermitente mientras el sitio se redesplega.
+exclude = ["brayandiazc\\.github\\.io"]


### PR DESCRIPTION
Arregla el job de CI que fallaba tras añadir la versión web.

- Excluye `_sidebar.md` (enlaces raíz-relativos de docsify).
- Excluye la URL de GitHub Pages (chequeo circular/intermitente).

🤖 Generated with [Claude Code](https://claude.com/claude-code)