### PR TITLE
release: v0.3.1 — fix de CI y scripts de tooling

### DIFF
--- a/.github/LABELS.md
+++ b/.github/LABELS.md
@@ -26,16 +26,11 @@ Etiquetas usadas en issues y pull requests de este repositorio.
 
 ## Crear las etiquetas
 
-Crea las etiquetas de contenido en GitHub (Settings → Labels) o con la CLI `gh`:
+La forma más simple es ejecutar el script incluido (requiere `gh` autenticado):
 
 ```bash
-gh label create error-contenido --description "Error técnico, ejemplo o errata" --color d73a4a
-gh label create sugerencia      --description "Propuesta de contenido"          --color 0e8a16
-gh label create pregunta        --description "Duda sobre el contenido"         --color d876e3
-gh label create contenido       --description "Cambios en lecciones"            --color 1d76db
-gh label create ejemplos        --description "Código de ejemplo"               --color fbca04
-gh label create proyectos       --description "Cambios en proyectos"            --color 5319e7
-gh label create documentacion   --description "Documentación de proceso"        --color 0075ca
-gh label create ia              --description "Capa de IA"                      --color c5def5
-gh label create ci-cd           --description "CI / tooling"                    --color ededed
+bash .github/scripts/setup-labels.sh
 ```
+
+Crea (o actualiza, con `--force`) todas las labels de este documento. También puedes
+crearlas a mano en GitHub (Settings → Labels) o con `gh label create` una por una.

--- a/.github/scripts/setup-labels.sh
+++ b/.github/scripts/setup-labels.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+
+# Crea/actualiza las labels del repositorio usando la CLI de GitHub (gh).
+# Requiere: GitHub CLI (gh) instalado y autenticado.
+# Uso: bash .github/scripts/setup-labels.sh
+
+set -e
+
+GREEN='\033[0;32m'
+BLUE='\033[0;34m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+echo -e "${BLUE}=== Configuración de labels ===${NC}\n"
+
+if ! command -v gh &> /dev/null; then
+	echo -e "${YELLOW}Error: GitHub CLI (gh) no está instalado.${NC}"
+	echo "Instálalo desde: https://cli.github.com/"
+	exit 1
+fi
+
+if ! gh auth status &> /dev/null; then
+	echo -e "${YELLOW}Error: no estás autenticado en GitHub CLI.${NC}"
+	echo "Ejecuta: gh auth login"
+	exit 1
+fi
+
+REPO=$(gh repo view --json nameWithOwner -q .nameWithOwner 2>/dev/null)
+if [ -z "$REPO" ]; then
+	echo -e "${YELLOW}Error: no se pudo detectar el repositorio.${NC}"
+	echo "Ejecuta este script desde el directorio del repositorio."
+	exit 1
+fi
+
+echo -e "${GREEN}Configurando labels para: $REPO${NC}"
+
+create_label() {
+	local name=$1
+	local color=$2
+	local description=$3
+	echo -e "Creando label: ${BLUE}$name${NC}"
+	gh label create "$name" --color "$color" --description "$description" --force 2>/dev/null || true
+}
+
+# ── Labels automáticos (usados por labeler.yml) ──────────────────────────────
+echo -e "\n${GREEN}Labels automáticos (labeler)${NC}"
+create_label "contenido"     "1D76DB" "Cambios en lecciones"
+create_label "ejemplos"      "FBCA04" "Código de ejemplo (.js / .html / .mjs)"
+create_label "proyectos"     "5319E7" "Cambios en proyectos"
+create_label "documentacion" "0075CA" "Documentación de proceso (docs/, README)"
+create_label "ia"            "C5DEF5" "Capa de IA (.claude, AGENTS.md)"
+create_label "ci-cd"         "EDEDED" "CI, workflows y tooling"
+
+# ── Labels manuales (issues) ─────────────────────────────────────────────────
+echo -e "\n${GREEN}Labels manuales${NC}"
+create_label "error-contenido"  "D73A4A" "Error técnico, ejemplo roto, errata o enlace roto"
+create_label "sugerencia"       "0E8A16" "Propuesta de lección, módulo, ejercicio o proyecto"
+create_label "pregunta"         "D876E3" "Duda sobre el contenido"
+create_label "good first issue" "7057FF" "Buen punto de entrada para nuevas personas"
+create_label "help wanted"      "008672" "Se agradece ayuda externa"
+create_label "dependencies"     "0366D6" "Actualizaciones de dependencias (Dependabot)"
+
+echo -e "\n${GREEN}¡Labels configurados!${NC}"
+echo -e "Ver labels en: ${BLUE}https://github.com/$REPO/labels${NC}\n"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 ## [Unreleased]
 
+## [0.3.1] - 2026-06-30
+
+### Added
+
+- Script `.github/scripts/format-markdown.sh` para formatear Markdown y ejemplos con
+  Prettier (`--write`/`--check`), más `.prettierrc` (`proseWrap: preserve`) y `.prettierignore`.
+- Script `.github/scripts/setup-labels.sh` para crear/actualizar las labels del repo con `gh`.
+
+### Fixed
+
+- CI: el chequeo de enlaces (lychee) fallaba por `_sidebar.md` (enlaces raíz-relativos que
+  necesita docsify) y por la URL de GitHub Pages; ahora se excluyen vía `lychee.toml`.
+
 ## [0.3.0] - 2026-06-30
 
 ### Added
@@ -70,7 +83,8 @@ y este proyecto adhiere a [Semantic Versioning](https://semver.org/lang/es/).
 
 <!--
 Enlaces de comparación entre versiones (ajusta a tu repositorio):
-[Unreleased]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.3.0...HEAD
+[Unreleased]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.3.1...HEAD
+[0.3.1]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.3.0...v0.3.1
 [0.3.0]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.2.0...v0.3.0
 [0.2.0]: https://github.com/brayandiazc/aprendiendo-javascript/compare/v0.1.0...v0.2.0
 [0.1.0]: https://github.com/brayandiazc/aprendiendo-javascript/releases/tag/v0.1.0


### PR DESCRIPTION
Patch sobre v0.3.0.

### Añadido
- Script de formateo (`format-markdown.sh`) con Prettier + `.prettierrc`/`.prettierignore`.
- Script `setup-labels.sh` para las labels del repo.

### Corregido
- CI: chequeo de enlaces (lychee) fallaba por `_sidebar.md` y la URL de Pages; excluidos vía `lychee.toml`.

Se etiquetará `v0.3.1` tras el merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)